### PR TITLE
Potential fix for code scanning alert no. 10: Executing a command with a relative path

### DIFF
--- a/src/main/java/utils/SystemOps.java
+++ b/src/main/java/utils/SystemOps.java
@@ -108,7 +108,7 @@ public class SystemOps {
     }
 
     private static void reloadDaemon() {
-        ProcessBuilder pb = new ProcessBuilder("sudo", "systemctl", "daemon-reload");
+        ProcessBuilder pb = new ProcessBuilder("/usr/bin/sudo", "systemctl", "daemon-reload");
         pb.inheritIO();
         try {
             Process process = pb.start();
@@ -122,7 +122,7 @@ public class SystemOps {
     }
 
     private static void enableService() {
-        ProcessBuilder pb = new ProcessBuilder("sudo", "systemctl", "enable", "edge-update.service");
+        ProcessBuilder pb = new ProcessBuilder("/usr/bin/sudo", "systemctl", "enable", "edge-update.service");
         pb.inheritIO();
         try {
             Process process = pb.start();
@@ -136,7 +136,7 @@ public class SystemOps {
     }
 
     public static void selfUninstall() {
-        ProcessBuilder pb = new ProcessBuilder("sudo", "systemctl", "disable", "edge-update.service");
+        ProcessBuilder pb = new ProcessBuilder("/usr/bin/sudo", "systemctl", "disable", "edge-update.service");
         pb.inheritIO();
         try {
             Process process = pb.start();


### PR DESCRIPTION
Potential fix for [https://github.com/SaptarshiSarkar12/EdgeUpdateService/security/code-scanning/10](https://github.com/SaptarshiSarkar12/EdgeUpdateService/security/code-scanning/10)

To fix the problem, we need to replace the relative path `"sudo"` with its absolute path `"/usr/bin/sudo"`. This ensures that the correct executable is always used, regardless of any changes to the PATH environment variable.

We will make the following changes:
- Update the `ProcessBuilder` commands in the `reloadDaemon`, `enableService`, and `selfUninstall` methods to use the absolute path `"/usr/bin/sudo"` instead of `"sudo"`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
