### PR TITLE
Potential fix for code scanning alert no. 12: Missing catch of NumberFormatException

### DIFF
--- a/src/main/java/utils/CheckUpdate.java
+++ b/src/main/java/utils/CheckUpdate.java
@@ -32,12 +32,19 @@ public class CheckUpdate {
     }
 
     public static int compareVersions(String v1, String v2) {
-        int[] version1 = Arrays.stream(v1.split("\\."))
-                .mapToInt(Integer::parseInt)
-                .toArray();
-        int[] version2 = Arrays.stream(v2.split("\\."))
-                .mapToInt(Integer::parseInt)
-                .toArray();
+        int[] version1;
+        int[] version2;
+        try {
+            version1 = Arrays.stream(v1.split("\\."))
+                    .mapToInt(Integer::parseInt)
+                    .toArray();
+            version2 = Arrays.stream(v2.split("\\."))
+                    .mapToInt(Integer::parseInt)
+                    .toArray();
+        } catch (NumberFormatException e) {
+            System.err.println("Invalid version format: " + e.getMessage());
+            return -1; // Indicate comparison failure
+        }
 
         for (int i = 0; i < Math.max(version1.length, version2.length); i++) {
             int num1 = i < version1.length ? version1[i] : 0;

--- a/src/main/java/utils/CheckUpdate.java
+++ b/src/main/java/utils/CheckUpdate.java
@@ -32,19 +32,12 @@ public class CheckUpdate {
     }
 
     public static int compareVersions(String v1, String v2) {
-        int[] version1;
-        int[] version2;
-        try {
-            version1 = Arrays.stream(v1.split("\\."))
-                    .mapToInt(Integer::parseInt)
-                    .toArray();
-            version2 = Arrays.stream(v2.split("\\."))
-                    .mapToInt(Integer::parseInt)
-                    .toArray();
-        } catch (NumberFormatException e) {
-            System.err.println("Invalid version format: " + e.getMessage());
-            return -1; // Indicate comparison failure
-        }
+        int[] version1 = Arrays.stream(v1.split("\\."))
+                .mapToInt(CheckUpdate::parseInteger)
+                .toArray();
+        int[] version2 = Arrays.stream(v2.split("\\."))
+                .mapToInt(CheckUpdate::parseInteger)
+                .toArray();
 
         for (int i = 0; i < Math.max(version1.length, version2.length); i++) {
             int num1 = i < version1.length ? version1[i] : 0;
@@ -54,5 +47,14 @@ public class CheckUpdate {
             }
         }
         return 0;
+    }
+
+    private static int parseInteger(String str) {
+        try {
+            return Integer.parseInt(str);
+        } catch (NumberFormatException e) {
+            System.out.println("Error while parsing integer: " + e.getMessage());
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/SaptarshiSarkar12/EdgeUpdateService/security/code-scanning/12](https://github.com/SaptarshiSarkar12/EdgeUpdateService/security/code-scanning/12)

To fix the problem, we need to catch the `NumberFormatException` that might be thrown by `Integer.parseInt` within the `compareVersions` method. This can be done by wrapping the parsing logic in a try-catch block. If an exception is caught, we should handle it appropriately, such as by logging an error message and returning a default value that indicates a comparison failure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
